### PR TITLE
feat: add labels query parameter to filter events by inference label

### DIFF
--- a/app/elastic.py
+++ b/app/elastic.py
@@ -237,6 +237,12 @@ def buildESEventQuery(queryparams):
         add_match_params(must_terms, must_not_terms,
                 "summary.inference_result.inferences.inference_id", codestring);
 
+    labelstring = queryparams.get('labels', type=str)
+    if labelstring is not None:
+        add_match_params(must_terms, must_not_terms,
+                "summary.inference_result.primary_inference.labels",
+                labelstring)
+
     return {
         'query': {
             'bool': {


### PR DESCRIPTION
## Summary

Adds a new `labels` query parameter to the event search endpoint, allowing users to filter events by their primary inference label.

## Changes

- **`app/elastic.py`**: Added parsing of the `labels` query parameter and integration into the Elasticsearch query via `add_match_params`, targeting the `summary.inference_result.primary_inference.labels` field.

This follows the same pattern used by the existing `codes` (inference_id) filter, supporting both inclusion and exclusion via the `add_match_params` helper.